### PR TITLE
Update Kernel.php

### DIFF
--- a/Foundation/Console/Kernel.php
+++ b/Foundation/Console/Kernel.php
@@ -37,7 +37,7 @@ class Kernel extends ConsoleKernel
 
         // Prevent from loading plugins (it could be error-prone if load plugins).
         if ($this->loadWordpressPlugins === false) {
-            define('WP_PLUGIN_DIR', '/NULL');
+            defined('WP_PLUGIN_DIR') or define('WP_PLUGIN_DIR', '/NULL');
         }
 
         $wp_load = realpath($app->basePath() . '/../../../wp-load.php');

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "laraish/framework",
-    "description": "The Laraish Framework for WordPress.",
+    "description": "The Laraish Framework for WordPress, updated fork.",
     "keywords": [
         "framework",
         "laravel",
@@ -9,8 +9,8 @@
     "license": "MIT",
     "homepage": "http://laravel.com",
     "support": {
-        "issues": "https://github.com/laravel/framework/issues",
-        "source": "https://github.com/laravel/framework"
+        "issues": "https://github.com/thanasisxan/laraish-framework/issues",
+        "source": "https://github.com/thanasisxan/laraish-framework"
     },
     "authors": [
         {
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": "^7.3",
-        "laravel/framework": "^8.0",
+        "php": "^8.0",
+        "laravel/framework": "^9.0",
         "laraish/contracts": "^2.0",
         "laraish/support": "^2.0",
         "laraish/pagination": "^2.0",
@@ -36,5 +36,23 @@
     },
     "scripts": {
         "fix-cs": ["prettier **/*.php --write"]
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/thanasisxan/laraish-contracts"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/thanasisxan/laraish-support"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/thanasisxan/laraish-pagination"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/thanasisxan/laraish-options"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "require": {
         "php": "^8.0",
         "laravel/framework": "^9.0",
-        "laraish/contracts": "^2.0",
-        "laraish/support": "^2.0",
-        "laraish/pagination": "^2.0",
-        "laraish/options": "^2.0"
+        "laraish/contracts": "^3.0",
+        "laraish/support": "^3.0",
+        "laraish/pagination": "^3.0",
+        "laraish/options": "^3.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Check if WP_PLUGIN_DIR constant is already defined in order to be able to run phpunit/pest tests without errors if the app is already bootstrapped